### PR TITLE
Generate OSGi metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
   <artifactId>plexus-classworlds</artifactId>
   <version>2.4.3-SNAPSHOT</version>
+  <packaging>bundle</packaging>
 
   <name>Plexus Classworlds</name>
   <description>A class loader framework</description>
@@ -39,6 +40,17 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <_nouses>true</_nouses>
+            <Export-Package>org.codehaus.classworlds.*;org.codehaus.plexus.classworlds.*</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
To allow artifact to be used as OSGi bundle proper OSGi manifest needs
to be generated using Apache Felix Bundle Plugin.
