### PR TITLE
PLX-467: [performance] use SecurityManager subclass to find the caller class

### DIFF
--- a/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
@@ -62,6 +62,17 @@ public class ClassRealm
 
     private static final boolean isParallelCapable = Closeable.class.isAssignableFrom( URLClassLoader.class );
 
+    private static final class CallContext extends SecurityManager
+    {
+        private static final CallContext self = new CallContext();
+
+        public static String getCallerClassName()
+        {
+            // 0 = us, 1 = our caller, 2 = their caller
+            return self.getClassContext()[2].getName();
+        }
+    }
+
     /**
      * Creates a new class realm.
      *
@@ -276,9 +287,7 @@ public class ClassRealm
          * NOTE: If this gets called from ClassLoader.getResource(String), delegate to the strategy. If this got called
          * directly by other code, only scan our class path as usual for an URLClassLoader.
          */
-        StackTraceElement caller = new Exception().getStackTrace()[1];
-
-        if ( "java.lang.ClassLoader".equals( caller.getClassName() ) )
+        if ( "java.lang.ClassLoader".equals( CallContext.getCallerClassName() ) )
         {
             return strategy.getResource( name );
         }
@@ -295,9 +304,7 @@ public class ClassRealm
          * NOTE: If this gets called from ClassLoader.getResources(String), delegate to the strategy. If this got called
          * directly by other code, only scan our class path as usual for an URLClassLoader.
          */
-        StackTraceElement caller = new Exception().getStackTrace()[1];
-
-        if ( "java.lang.ClassLoader".equals( caller.getClassName() ) )
+        if ( "java.lang.ClassLoader".equals( CallContext.getCallerClassName() ) )
         {
             return strategy.getResources( name );
         }


### PR DESCRIPTION
This is a proof-of-concept PR for review/testing - we may want to keep the stack trace approach as a fall back in case there's a runtime problem using the SecurityManager subclass. The performance impact of this change still needs to be investigated in both large and small applications.
