### PR TITLE
PLX-467: [performance] simplified getResource{,s} that does not need to check caller stack reflectively

### DIFF
--- a/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
+++ b/src/main/java/org/codehaus/plexus/classworlds/realm/ClassRealm.java
@@ -276,12 +276,23 @@ public class ClassRealm
         return resource != null ? resource : strategy.getResource( name );
     }
 
+    public URL findResource( String name )
+    {
+        return super.findResource( name );
+    }
+
     public Enumeration<URL> getResources( String name )
         throws IOException
     {
         Collection<URL> resources = new LinkedHashSet<URL>( Collections.list( super.getResources( name ) ) );
         resources.addAll( Collections.list( strategy.getResources( name ) ) );
         return Collections.enumeration( resources );
+    }
+
+    public Enumeration<URL> findResources( String name )
+        throws IOException
+    {
+        return super.findResources( name );
     }
 
     // ----------------------------------------------------------------------------


### PR DESCRIPTION
See discussion in [PLX-467](https://jira.codehaus.org/browse/PLX-467) and compare to #6 and #7.
